### PR TITLE
Fix grave entity regex in aff builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ hu_HU.aff: magyar.aff
 		A-ZÁÉÍÓÖŐÚÜŰ a-záéíóöőúüű | sed 's/q\([^[]*\]\)/-\1/' | \
                 bin/newsyntax >$(ROOTDIR)/hu_HU_morph.aff                
 	@cat $(ROOTDIR)/hu_HU_morph.aff | bin/aff2gen | \
-	        sed 's/&i[ua]grave;//g;s/&oslash;//g' >$(ROOTDIR)/hu_HU_gen.aff
+	        sed 's/&[iua]grave;//g;s/&oslash;//g' >$(ROOTDIR)/hu_HU_gen.aff
 	@cat $(ROOTDIR)/hu_HU_gen.aff | \
 		LC_ALL=C sed 's/\t\([^p].\|.[^h]\):[^\t]*//g' >$(ROOTDIR)/hu_HU.aff
 


### PR DESCRIPTION
The `sed` processing during conversion of `hu_HU_morph.aff` to `hu_HU_gen.aff` is currently trying to strip the entities `&iugrave;` and `&iagrave;`, which don't exist. 

This results in `&agrave;` and `&ugrave;` entities remaining in the output `hu_HU.aff` file.

I think instead it's meant to be stripping `&igrave;`, `&agrave;` and `&ugrave;`, which is what this PR achieves.

There are still other HTML entities remaining in the output `hu_HU.aff` file, so this isn't a full solution, but it is at least now doing what I think was intended.